### PR TITLE
Better error logging

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,4 @@
-const { compose, evolve, pick, tap } = require('ramda')
+const { compose, evolve, is, pick, tap, when } = require('ramda')
 
 module.exports = compose(
   tap(console.info),
@@ -6,5 +6,6 @@ module.exports = compose(
   evolve({
     req: pick(['headers', 'method', 'url']),
     res: pick(['statusCode'])
-  })
+  }),
+  when(is(Error), pick(['message', 'name', 'stack']))
 )

--- a/test/logger.js
+++ b/test/logger.js
@@ -49,4 +49,20 @@ describe('logger', function() {
   it('passes thru other message properties unchanged', function() {
     expect(output.foo).to.equal('bar')
   })
+
+  describe('when used as the errLogger', function() {
+    const err = JSON.parse(logger(new Error('message')))
+
+    it('includes the error message', function() {
+      expect(err.message).to.equal('message')
+    })
+
+    it('includes the error name', function() {
+      expect(err.name).to.equal('Error')
+    })
+
+    it('includes the error stack', function() {
+      expect(err.stack).to.exist
+    })
+  })
 })


### PR DESCRIPTION
![logging](http://d2ouvy59p0dg6k.cloudfront.net/img/original/_______________________________________________________________.jpg)

Now includes the `message`, `name`, and `stack` in the logs for regular system `Error`s.