### PR TITLE
Add CORS support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,6 @@
 # API
 
+- [`cors`](#cors)           - CORS support wrapper
 - [`html`](#html)           - response helper, type `text/html`
 - [`json`](#json)           - response helper, type `application/json`
 - [`logger`](#logger)       - json request logger
@@ -10,6 +11,39 @@
 - [`routes`](#routes)       - maps express-style route patterns to handler functions
 - [`send`](#send)           - basic response helper
 - [`static`](#static)       - static file serving handler
+
+### cors
+
+```haskell
+((Request -> (Response | Promise Response)), Object) -> Request -> Promise Response
+```
+
+Wraps a top-level handler function to add support for [CORS](http://devdocs.io/http/access_control_cors).  Lifts the handler into a `Promise` chain, so the handler can respond with either a [`Response`](https://github.com/articulate/paperplane/blob/master/docs/getting-started.md#response-object), or a `Promise` that resolves with one.  Also accepts an object with the following optional properties to override the default CORS behavior.
+
+| Property | Type | Overridden header | Default |
+| -------- | ---- | ----------------- | ------- |
+| `credentials` | `String` | `access-control-allow-credentials` | `true` |
+| `headers` | `String` | `access-control-allow-headers` | `content-type` |
+| `methods` | `String` | `access-control-allow-methods` | `GET,POST,OPTIONS,PUT,PATCH,DELETE` |
+| `origin`  | `String` | `access-control-allow-origin` | `*` |
+
+```js
+const { always } = require('ramda')
+const http = require('http')
+const { cors, mount, send } = require('paperplane')
+
+const endpoint = req =>
+  Promise.resolve(req.body).then(send)
+
+const opts = {
+  headers: 'x-custom-header',
+  methods: 'GET,PUT'
+}
+
+const app = cors(endpoint, opts)
+
+http.createServer(mount(app)).listen(3000)
+```
 
 ### html
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+exports.cors      = require('./lib/cors')
 exports.html      = require('./lib/html')
 exports.json      = require('./lib/json')
 exports.logger    = require('./lib/logger')

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,0 +1,26 @@
+const { lensProp, merge, over } = require('ramda')
+
+const defs = {
+  credentials: 'true',
+  headers: 'content-type',
+  methods: 'GET,POST,OPTIONS,PUT,PATCH,DELETE',
+  origin: '*'
+}
+
+const basics = opts => ({
+  'access-control-allow-credentials': opts.credentials || defs.credentials,
+  'access-control-allow-origin': opts.origin || defs.origin
+})
+
+const options = opts => ({ headers }) => ({
+  headers: {
+    'access-control-allow-headers': opts.headers || headers['access-control-request-headers'] || defs.headers,
+    'access-control-allow-methods': opts.methods || headers['access-control-request-method'] || defs.methods
+  },
+  statusCode: 204
+})
+
+module.exports = (app, opts={}) => req =>
+  Promise.resolve(req)
+    .then(req.method === 'OPTIONS' && options(opts) || app)
+    .then(over(lensProp('headers'), merge(basics(opts))))

--- a/test/cors.js
+++ b/test/cors.js
@@ -1,0 +1,102 @@
+const { always: K } = require('ramda')
+const http    = require('http')
+const request = require('supertest')
+
+const { cors, mount, send } = require('..')
+
+describe('cors', function() {
+  describe('with no options specified', function() {
+    const app    = cors(K(send())),
+          server = http.createServer(mount(app)),
+          agent  = request.agent(server)
+
+    describe('receiving an OPTIONS request', function() {
+      it('responds with a 204', function(done) {
+        agent.options('/').expect(204, done)
+      })
+
+      it('defaults the credentials to true', function(done) {
+        agent.options('/').expect('access-control-allow-credentials', 'true', done)
+      })
+
+      it('defaults the headers to "content-type"', function(done) {
+        agent.options('/').expect('access-control-allow-headers', 'content-type', done)
+      })
+
+      it('defaults the methods to "GET,POST,OPTIONS,PUT,PATCH,DELETE"', function(done) {
+        agent.options('/').expect('access-control-allow-methods', 'GET,POST,OPTIONS,PUT,PATCH,DELETE', done)
+      })
+
+      it('defaults the origin to "*"', function(done) {
+        agent.options('/').expect('access-control-allow-origin', '*', done)
+      })
+
+      it('reflects the supplied "access-control-request-headers"', function(done) {
+        agent.options('/')
+          .set('access-control-request-headers', 'content-length')
+          .expect('access-control-allow-headers', 'content-length', done)
+      })
+
+      it('reflects the supplied "access-control-request-method"', function(done) {
+        agent.options('/')
+          .set('access-control-request-method', 'POST')
+          .expect('access-control-allow-methods', 'POST', done)
+      })
+    })
+
+    describe('receiving the actual request', function() {
+      it('defaults the credentials to true', function(done) {
+        agent.get('/').expect('access-control-allow-credentials', 'true', done)
+      })
+
+      it('defaults the origin to "*"', function(done) {
+        agent.get('/').expect('access-control-allow-origin', '*', done)
+      })
+    })
+  })
+
+  describe('with options specified', function() {
+    const opts = {
+      credentials: 'false',
+      headers: 'x-custom-header',
+      methods: 'GET,PUT',
+      origin: 'https://articulate.com'
+    }
+
+    const app    = cors(K(send()), opts),
+          server = http.createServer(mount(app)),
+          agent  = request.agent(server)
+
+    describe('receiving an OPTIONS request', function() {
+      it('responds with a 204', function(done) {
+        agent.options('/').expect(204, done)
+      })
+
+      it('overrides the default credentials', function(done) {
+        agent.options('/').expect('access-control-allow-credentials', opts.credentials, done)
+      })
+
+      it('overrides the default headers', function(done) {
+        agent.options('/').expect('access-control-allow-headers', opts.headers, done)
+      })
+
+      it('overrides the default methods', function(done) {
+        agent.options('/').expect('access-control-allow-methods', opts.methods, done)
+      })
+
+      it('overrides the default origin', function(done) {
+        agent.options('/').expect('access-control-allow-origin', opts.origin, done)
+      })
+    })
+
+    describe('receiving the actual request', function () {
+      it('overrides the default credentials', function(done) {
+        agent.get('/').expect('access-control-allow-credentials', opts.credentials, done)
+      })
+
+      it('overrides the default origin', function(done) {
+        agent.get('/').expect('access-control-allow-origin', opts.origin, done)
+      })
+    })
+  })
+})


### PR DESCRIPTION
![cores](https://www.kentlikadin.com/wp-content/uploads/2015/07/yemek47.jpg)

:man_shrugging: Close enough!

Since CORS is a non-trivial problem, but still a _very common_ problem, this PR adds basic CORS support to `paperplane`.  Should cover about 99% of use cases with sane defaults.