### PR TITLE
move handling of boom and joi errors before error logging occurs

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -2,6 +2,8 @@ const { assoc, ifElse, is, merge, pick, pipe, prop, when } = require('ramda')
 
 const json = require('./json')
 
+const rethrow = err => { throw err }
+
 const boomError = ({ output: { payload, statusCode } }) =>
   merge(json(payload), { statusCode })
 
@@ -14,9 +16,12 @@ const joiError = pipe(
 const systemError = ({ message, name, statusCode=500 }) =>
   merge(json({ message, name }), { statusCode })
 
-module.exports =
+exports.error =
+  when(is(Error), systemError)
+
+exports.handleableErrors =
   when(is(Error),
     ifElse(prop('isBoom'), boomError,
     ifElse(prop('isJoi'), joiError,
-    systemError)
+    rethrow)
   ))

--- a/lib/mount.js
+++ b/lib/mount.js
@@ -1,11 +1,11 @@
 const etag       = require('etag')
 const { Stream } = require('stream')
 
-const error        = require('./error')
 const getBody      = require('./get-body')
 const parseCookies = require('./parse-cookies')
 const parseUrl     = require('./parse-url')
 const { log, rethrow } = require('./util')
+const { error, handleableErrors } = require('./error')
 
 const { byteLength, isBuffer } = Buffer
 
@@ -16,6 +16,7 @@ const mount = (app, { errLogger, logger }={}) =>
       .then(parseUrl)
       .then(parseCookies)
       .then(app)
+      .catch(handleableErrors)
       .catch(rethrow(errLogger))
       .catch(error)
       .then(write(res))


### PR DESCRIPTION
![](http://www.oshatrain.org/courses/images/719distracted.jpg)

moves the conversion of Boom and Joi errors to json responses to before the error logger is called.  This allows airbrake notification to be in the errLogger function and only true errors will be sent to airbrake.

fixes #8 

@flintinatux @tecnobrat 