### PR TITLE
Revert #9

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -2,8 +2,6 @@ const { assoc, ifElse, is, merge, pick, pipe, prop, when } = require('ramda')
 
 const json = require('./json')
 
-const rethrow = err => { throw err }
-
 const boomError = ({ output: { payload, statusCode } }) =>
   merge(json(payload), { statusCode })
 
@@ -16,12 +14,9 @@ const joiError = pipe(
 const systemError = ({ message, name, statusCode=500 }) =>
   merge(json({ message, name }), { statusCode })
 
-exports.error =
-  when(is(Error), systemError)
-
-exports.handleableErrors =
+module.exports =
   when(is(Error),
     ifElse(prop('isBoom'), boomError,
     ifElse(prop('isJoi'), joiError,
-    rethrow)
+    systemError)
   ))

--- a/lib/mount.js
+++ b/lib/mount.js
@@ -1,11 +1,11 @@
 const etag       = require('etag')
 const { Stream } = require('stream')
 
+const error        = require('./error')
 const getBody      = require('./get-body')
 const parseCookies = require('./parse-cookies')
 const parseUrl     = require('./parse-url')
 const { log, rethrow } = require('./util')
-const { error, handleableErrors } = require('./error')
 
 const { byteLength, isBuffer } = Buffer
 
@@ -16,7 +16,6 @@ const mount = (app, { errLogger, logger }={}) =>
       .then(parseUrl)
       .then(parseCookies)
       .then(app)
-      .catch(handleableErrors)
       .catch(rethrow(errLogger))
       .catch(error)
       .then(write(res))


### PR DESCRIPTION
![sour-patch-kid](https://cloud.githubusercontent.com/assets/888052/24471225/6fae8160-148f-11e7-8030-77a2fef2f67d.gif)

When I first glanced at this code it seemed fine, but in the end it fails to accomplish the filtering of 404's that we intended, for two reasons:

1.  `paperplane` outputs `http-error`'s for not found routes, not `boom`'s (hence [this error](https://articulate.airbrake.io/projects/124884/groups/1911804228964009171?tab=overview)).
2.  Explicit 500 `boom`'s will be ignored, instead of notifying airbrake.

The best solution is to add a filter:

```js
airbrake.addFilter(notice => {
  const err = notice.errors[0]
  const statusCode = err.isBoom ? err.output.statusCode : err.statusCode
  return statusCode && statusCode >= 500 && notice
})
```

Then, because `airbrake` doesn't auto-magically attach your request data to caught errors, you should wrap your app with [`paperplane-airbrake`](https://github.com/articulate/paperplane-airbrake).  That way you can see the request url, method, user-agent, etc.

ping @kdstew @pklingem @cdwills 