### PR TITLE
Support HEAD if GET handler supplied

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -140,6 +140,8 @@ Logs will be formatted as `json`, similar to below:
 
 Maps handler functions to request methods.  Returns a handler function.  If the method of an incoming request doesn't match, it rejects with a `404 Not Found`.  Use in combination with [`routes`](#routes) to build a routing table of any complexity.
 
+**Note:** If you supply a `GET` handler, `paperplane` will also use it to handle `HEAD` requests.
+
 ```js
 const http = require('http')
 const { methods, mount } = require('paperplane')

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,11 +1,11 @@
-const { compose, evolve, is, pick, tap, when } = require('ramda')
+const { evolve, is, pick, pipe, tap, when } = require('ramda')
 
-module.exports = compose(
-  tap(console.info),
-  JSON.stringify,
+module.exports = pipe(
+  when(is(Error), pick(['message', 'name', 'stack'])),
   evolve({
     req: pick(['headers', 'method', 'url']),
     res: pick(['statusCode'])
   }),
-  when(is(Error), pick(['message', 'name', 'stack']))
+  JSON.stringify,
+  tap(console.info)
 )

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -1,4 +1,9 @@
+const { compose, prop, when } = require('ramda')
 const { NotFound } = require('http-errors')
+
+const { copy } = require('./util')
+
+const addHead = when(prop('GET'), copy('GET', 'HEAD'))
 
 const methods = handlers => req =>
   new Promise((resolve, reject) => {
@@ -7,4 +12,4 @@ const methods = handlers => req =>
       : reject(new NotFound())
   })
 
-module.exports = methods
+module.exports = compose(methods, addHead)

--- a/lib/mount.js
+++ b/lib/mount.js
@@ -18,10 +18,10 @@ const mount = (app, { errLogger, logger }={}) =>
       .then(app)
       .catch(rethrow(errLogger))
       .catch(error)
-      .then(write(res))
+      .then(write(req, res))
       .then(log(logger, { req, res }))
 
-const write = res => ({ body, headers={}, statusCode=200 }) => {
+const write = (req, res) => ({ body, headers={}, statusCode=200 }) => {
   res.statusCode = statusCode
 
   for (var name in headers)
@@ -39,7 +39,7 @@ const write = res => ({ body, headers={}, statusCode=200 }) => {
   const length = isBuffer(body) ? body.length : byteLength(body)
   res.setHeader('content-length', length)
   res.setHeader('etag', etag(body))
-  res.end(body)
+  res.end(req.method === 'HEAD' ? undefined : body)
 }
 
 module.exports = mount

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,7 +1,10 @@
-const { assoc, flip, is, when } = require('ramda')
+const { assoc, curryN, flip, is, when } = require('ramda')
 
 exports.assign = (key, obj) =>
   flip(assoc(key))(obj)
+
+exports.copy = curryN(3, (frum, to, obj) =>
+  assoc(to, obj[frum], obj))
 
 exports.log = (logger, output) => () =>
   typeof logger === 'function' && logger(output)

--- a/test/methods.js
+++ b/test/methods.js
@@ -17,6 +17,10 @@ describe('methods', function() {
     agent.get('/').expect(200, 'GET')
   )
 
+  it('also responds to HEAD if GET provided', () =>
+    agent.head('/').expect(200)
+  );
+
   it('404 Not Founds when no matching method is found', () =>
     agent.post('/').send({}).expect(404)
   )


### PR DESCRIPTION
![unsupported head request](https://c2.staticflickr.com/8/7532/26925269965_71b4b4375a_b.jpg)

Fixes #14 to meet [the spec](http://devdocs.io/http/methods/head).  Copies any supplied `GET` handler to be `HEAD`, and then drops the `body` before ending the request.

ping @cdwills, and especially @tecnobrat because he'll be so proud