### PR TITLE
Use Boom instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,45 @@
   <a href="https://www.npmjs.com/package/paperplane"><img src="https://img.shields.io/npm/v/paperplane.svg" alt="npm version" style="max-width:100%;"></a> <a href="https://www.npmjs.com/package/paperplane"><img src="https://img.shields.io/npm/dm/paperplane.svg" alt="npm downloads" style="max-width:100%;"></a> <a href="https://travis-ci.org/articulate/paperplane"><img src="https://travis-ci.org/articulate/paperplane.svg?branch=master" alt="Build Status" style="max-width:100%;"></a> <a href="https://nodesecurity.io/orgs/articulate/projects/103be316-79be-4dd0-9d9c-73674b8ad85b"><img src="https://nodesecurity.io/orgs/articulate/projects/103be316-79be-4dd0-9d9c-73674b8ad85b/badge" alt="NSP Vuln Status"></a>
 </p>
 
-## Usage
-
-Install via `npm` or `yarn` with:
-
-    npm install --save paperplane
-
-or:
-
-    yarn add paperplane
-
-Then require in your project with:
-
-```js
-const paperplane = require('paperplane')
-```
-
 ## Documentation
 
 - [Getting started guide](https://github.com/articulate/paperplane/blob/master/docs/getting-started.md)
 - [API docs](https://github.com/articulate/paperplane/blob/master/docs/API.md)
+
+## Introduction
+
+The main goal of `paperplane` is to make building a `node.js` server easy, without all of the configuration or imperative boilerplate required for other server frameworks.  If you prefer to build apps with function composition or even a point-free style, then `paperplane` is for you.
+
+With `paperplane` you get all of these out-of-the-box:
+
+- pure, functional, Promise-based [route handlers](https://github.com/articulate/paperplane/blob/master/docs/getting-started.md#basic-concepts)
+- composeable json [body parsing](https://github.com/articulate/paperplane/blob/master/docs/API.md#parsejson)
+- dead-simple [routing functions](https://github.com/articulate/paperplane/blob/master/docs/API.md#routes)
+- several common [response helpers](https://github.com/articulate/paperplane/blob/master/docs/getting-started.md#response-object)
+- json-formatted [logging](https://github.com/articulate/paperplane/blob/master/docs/API.md#logger)
+- easily configurable [CORS support](https://github.com/articulate/paperplane/blob/master/docs/API.md#cors)
+- plug-n-play [static file serving](https://github.com/articulate/paperplane/blob/master/docs/API.md#static)
+
+Let's try a quick Hello World example server.  It accepts a `:name` param in the url, and then includes that name in the `json` response body.
+
+```js
+const { compose } = require('ramda')
+const http = require('http')
+const { json, logger, methods, mount, routes } = require('paperplane')
+
+const hello = req => ({
+  message: `Hello ${req.params.name}!`
+})
+
+const app = routes({
+  `/hello/:name`: methods({
+    GET: compose(json, hello)
+  })
+})
+
+const opts = { errLogger: logger, logger }
+
+http.createServer(mount(app, opts)).listen(3000, logger)
+```
+
+So simple and functional, with an easily readable routing table and pure functions for the route handler.  If that sounds like fun to you, then read the [Getting started guide](https://github.com/articulate/paperplane/blob/master/docs/getting-started.md) or the [API docs](https://github.com/articulate/paperplane/blob/master/docs/API.md) to learn more.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,7 @@
 - [Basic concepts](#basic-concepts)
   - [`Request` object](#request-object)
   - [`Response` object](#response-object)
+  - [Errors](#errors)
 - [Example application](#example-application)
 
 ## Motivation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Getting started
 
 - [Motivation](#motivation)
 - [Basic concepts](#basic-concepts)

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -1,5 +1,5 @@
+const Boom = require('boom')
 const { compose, prop, when } = require('ramda')
-const { NotFound } = require('http-errors')
 
 const { copy } = require('./util')
 
@@ -9,7 +9,7 @@ const methods = handlers => req =>
   new Promise((resolve, reject) => {
     handlers[req.method]
       ? resolve(handlers[req.method](req))
-      : reject(new NotFound())
+      : reject(Boom.notFound())
   })
 
 module.exports = compose(methods, addHead)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,6 +1,6 @@
-const { merge }    = require('ramda')
-const { NotFound } = require('http-errors')
-const pathMatch    = require('path-match')()
+const Boom      = require('boom')
+const { merge } = require('ramda')
+const pathMatch = require('path-match')()
 
 const routes = handlers => req =>
   new Promise((resolve, reject) => {
@@ -8,7 +8,7 @@ const routes = handlers => req =>
       const params = pathMatch(route)(req.pathname)
       if (params) return resolve(handlers[route](merge(req, { params })))
     }
-    reject(new NotFound())
+    reject(Boom.notFound())
   })
 
 module.exports = routes

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "test": "mocha --reporter dot"
   },
   "dependencies": {
+    "boom": "^5.1.0",
     "cookie": "^0.3.1",
     "etag": "^1.7.0",
-    "http-errors": "^1.5.1",
     "media-typer": "^0.3.0",
     "path-match": "^1.2.4",
     "qs": "^6.3.0",
@@ -29,8 +29,8 @@
     "type-is": "^1.6.14"
   },
   "devDependencies": {
-    "boom": "^4.2.0",
     "chai": "^3.5.0",
+    "http-errors": "^1.6.1",
     "joi": "^10.2.0",
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,9 +156,9 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-boom@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.2.0.tgz#c1a74174b11fbba223f6162d4fd8851a1b82a536"
+boom@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-5.1.0.tgz#0308fa8e924cd6d42d9c3bf4883bdc98f0e71df8"
   dependencies:
     hoek "4.x.x"
 
@@ -387,7 +387,7 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@~1.1.0:
+depd@1.1.0, depd@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
 
@@ -766,12 +766,13 @@ htmlparser2@3.8.x:
     entities "1.0"
     readable-stream "1.1"
 
-http-errors@^1.5.1, http-errors@~1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.5.1.tgz#788c0d2c1de2c81b9e6e8c01843b6b97eb920750"
+http-errors@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.1.tgz#5f8b8ed98aca545656bf572997387f904a722257"
   dependencies:
+    depd "1.1.0"
     inherits "2.0.3"
-    setprototypeof "1.0.2"
+    setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
 http-errors@~1.4.0:
@@ -780,6 +781,14 @@ http-errors@~1.4.0:
   dependencies:
     inherits "2.0.1"
     statuses ">= 1.2.1 < 2"
+
+http-errors@~1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.5.1.tgz#788c0d2c1de2c81b9e6e8c01843b6b97eb920750"
+  dependencies:
+    inherits "2.0.3"
+    setprototypeof "1.0.2"
+    statuses ">= 1.3.1 < 2"
 
 http-signature@~1.1.0:
   version "1.1.1"
@@ -1782,6 +1791,10 @@ set-immediate-shim@^1.0.1:
 setprototypeof@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.2.tgz#81a552141ec104b88e89ce383103ad5c66564d08"
+
+setprototypeof@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
 shelljs@0.3.x:
   version "0.3.0"


### PR DESCRIPTION
![boom](https://images-na.ssl-images-amazon.com/images/S/cmx-images-prod/Item/34898/DIG002565_2._SX1280_QL80_TTD_.jpg)

In an effort to ease the filtering of errors sent to `Airbrake`, I'm switching `paperplane` to use `Boom` for error responses (really just 404's), since they are easier to filter.  Simple change, with no change to the actual `http` response code, but a breaking change nonetheless.

I also added an example app to the readme, because the readme was looking a little bare in `npm`.

## to test:
- [x] Either `yarn link` this into your app locally, or volume it into a `docker-compose` app.  Ask me if you need help.
- [x] Visit a url that should return a `404`.
- [x] You should still get a `404`.

ping @cdwills @spencerfdavis @pklingem 