### PR TITLE
Add support for 'if-none-match' request header

### DIFF
--- a/lib/mount.js
+++ b/lib/mount.js
@@ -26,7 +26,7 @@ const write = (req, res) => ({ body, headers={}, statusCode=200 }) => {
     res.setHeader(name, headers[name])
 
   const requestEtag = req.headers['if-none-match']
-  const bodyEtag = !(body instanceof Stream) ? etag(body || '') : undefined
+  const bodyEtag = !(body instanceof Stream) && etag(body || '')
   const supports304Response = statusCode === 200 && ['GET', 'HEAD'].includes(req.method)
 
   if (supports304Response && requestEtag && requestEtag === bodyEtag) {

--- a/lib/mount.js
+++ b/lib/mount.js
@@ -22,10 +22,20 @@ const mount = (app, { errLogger, logger }={}) =>
       .then(log(logger, { req, res }))
 
 const write = (req, res) => ({ body, headers={}, statusCode=200 }) => {
-  res.statusCode = statusCode
-
   for (var name in headers)
     res.setHeader(name, headers[name])
+
+  const requestEtag = req.headers['if-none-match']
+  const bodyEtag = !(body instanceof Stream) ? etag(body || '') : undefined
+  const supports304Response = statusCode === 200 && ['GET', 'HEAD'].includes(req.method)
+
+  if (supports304Response && requestEtag && requestEtag === bodyEtag) {
+    res.setHeader('etag', bodyEtag)
+    res.statusCode = 304
+    return res.end()
+  }
+
+  res.statusCode = statusCode
 
   if (!body)
     return res.end()
@@ -38,7 +48,7 @@ const write = (req, res) => ({ body, headers={}, statusCode=200 }) => {
 
   const length = isBuffer(body) ? body.length : byteLength(body)
   res.setHeader('content-length', length)
-  res.setHeader('etag', etag(body))
+  res.setHeader('etag', bodyEtag)
   res.end(req.method === 'HEAD' ? undefined : body)
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "hint": "jshint --reporter=node_modules/jshint-stylish .",
     "start": "node demo/index.js",
     "start:dev": "nodemon -w . demo/index.js",
-    "test": "mocha --reporter dot"
+    "test": "mocha --reporter dot",
+    "test:dev": "yarn run test -- -w"
   },
   "dependencies": {
     "boom": "^5.1.0",

--- a/test/mount.js
+++ b/test/mount.js
@@ -80,7 +80,7 @@ describe('mount', () => {
     )
 
     it('accepts undefined to denote a no-content body', () =>
-      agent.get('/none').expect(200)
+      agent.get('/none').expect(200, '')
     )
   })
 

--- a/test/mount.js
+++ b/test/mount.js
@@ -66,6 +66,24 @@ describe('mount', () => {
     })
   })
 
+  describe('request headers', () => {
+    describe('if-none-match header does not match etag', () => {
+      it('returns 200 with full response body', () =>
+        agent.get('/string').set({ 'if-none-match': '"not-the-right-etag"' })
+          .expect(200, 'string')
+          .expect('etag', '"6-tFz/4ITdPSDZKL7oXnsPIQ"')
+      )
+    })
+
+    describe('if-none-match header matches etag', () => {
+      it('returns 304 with empty response body', () =>
+        agent.get('/string').set({ 'if-none-match': '"6-tFz/4ITdPSDZKL7oXnsPIQ"' })
+          .expect(304, '')
+          .expect('etag', '"6-tFz/4ITdPSDZKL7oXnsPIQ"')
+      )
+    })
+  })
+
   describe('response body', () => {
     it('accepts a buffer', () =>
       agent.get('/buffer').expect(200, 'buffer')

--- a/test/static.js
+++ b/test/static.js
@@ -1,4 +1,5 @@
 const { always: K  } = require('ramda')
+const { EOL } = require('os')
 const http    = require('http')
 const request = require('supertest')
 
@@ -14,7 +15,7 @@ describe('static', () => {
         agent  = request.agent(server)
 
   it('responds with found static files', () =>
-    agent.get('/pub/static-file.txt').expect(200, 'testing testing\n')
+    agent.get('/pub/static-file.txt').expect(200, 'testing testing' + EOL)
   )
 
   it('404 Not Founds for missing static files', () =>


### PR DESCRIPTION
A few odds and ends plus support for the 'if-none-match' request header for GET and HEAD requests.

![](https://media2.giphy.com/media/dh2XvZthDl7ag/giphy.gif)