### PR TITLE
parseInt the content-length

### DIFF
--- a/lib/clean-request.js
+++ b/lib/clean-request.js
@@ -1,0 +1,13 @@
+const { pick } = require('ramda')
+
+module.exports = pick([
+  'body',
+  'cookies',
+  'headers',
+  'method',
+  'params',
+  'pathname',
+  'protocol',
+  'query',
+  'url'
+])

--- a/lib/get-body.js
+++ b/lib/get-body.js
@@ -1,10 +1,10 @@
+const { compose, path, when } = require('ramda')
 const rawBody = require('raw-body')
 const typer   = require('media-typer')
-const { path, when } = require('ramda')
 
 const { assign } = require('./util')
 
-const contentLength = path(['headers', 'content-length'])
+const contentLength = compose(parseInt, path(['headers', 'content-length']))
 
 const getBody = req => {
   const encoding = typer.parse(req).parameters.charset || 'utf8'

--- a/lib/mount.js
+++ b/lib/mount.js
@@ -1,6 +1,7 @@
 const etag       = require('etag')
 const { Stream } = require('stream')
 
+const cleanRequest = require('./clean-request')
 const error        = require('./error')
 const getBody      = require('./get-body')
 const parseCookies = require('./parse-cookies')
@@ -15,6 +16,7 @@ const mount = (app, { errLogger, logger }={}) =>
       .then(getBody)
       .then(parseUrl)
       .then(parseCookies)
+      .then(cleanRequest)
       .then(app)
       .catch(rethrow(errLogger))
       .catch(error)

--- a/test/mount.js
+++ b/test/mount.js
@@ -82,6 +82,14 @@ describe('mount', () => {
           .expect('etag', '"6-tFz/4ITdPSDZKL7oXnsPIQ"')
       )
     })
+
+    describe('when content-length is "0"', () => {
+      it('does not parse the body', () =>
+        agent.get('/body')
+          .set('content-length', '0')
+          .expect(200)
+      )
+    })
   })
 
   describe('response body', () => {


### PR DESCRIPTION
![parseInt](https://pics.onsizzle.com/parseint-100-bug-in-javascript-24798393.png)

Because headers are strings, even if they are... numbers.

## to test:
- [x] Let the tests run.
- [x] Wait until they turn green.
- [x] Merge if you like the code.

ping @cdwills 