### PR TITLE
Add CORS headers for error responses

### DIFF
--- a/lib/cors-error.js
+++ b/lib/cors-error.js
@@ -1,0 +1,12 @@
+class CorsError extends Error {
+  static unwrap(err) {
+    return err instanceof CorsError ? err.err : err
+  }
+
+  constructor(err, headers, ...params) {
+    super(...params)
+    Object.assign(this, { err, headers })
+  }
+}
+
+module.exports = CorsError

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,4 +1,5 @@
 const { lensProp, merge, over } = require('ramda')
+const CorsError = require('./cors-error')
 
 const defs = {
   credentials: 'true',
@@ -24,3 +25,4 @@ module.exports = (app, opts={}) => req =>
   Promise.resolve(req)
     .then(req.method === 'OPTIONS' && options(opts) || app)
     .then(over(lensProp('headers'), merge(basics(opts))))
+    .catch(err => { throw new CorsError(err, basics(opts)) })

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,6 +1,21 @@
-const { assoc, ifElse, is, merge, pick, pipe, prop, when } = require('ramda')
+const {
+  assoc,
+  compose,
+  converge,
+  ifElse,
+  is,
+  lensProp,
+  merge,
+  objOf,
+  over,
+  pick,
+  pipe,
+  prop,
+  when,
+} = require('ramda')
 
 const json = require('./json')
+const CorsError = require('./cors-error')
 
 const boomError = ({ output: { payload, statusCode } }) =>
   merge(json(payload), { statusCode })
@@ -14,9 +29,16 @@ const joiError = pipe(
 const systemError = ({ message, name, statusCode=500 }) =>
   merge(json({ message, name }), { statusCode })
 
-module.exports =
-  when(is(Error),
-    ifElse(prop('isBoom'), boomError,
-    ifElse(prop('isJoi'), joiError,
-    systemError)
-  ))
+module.exports = pipe(
+  ifElse(is(CorsError), pick([ 'err', 'headers' ]), objOf('err')),
+  over(
+    lensProp('err'),
+    when(is(Error),
+      ifElse(prop('isBoom'), boomError,
+      ifElse(prop('isJoi'), joiError,
+      systemError)
+    ))),
+  converge(over(lensProp('headers')), [
+    compose(merge, prop('headers')),
+    prop('err'),
+  ]))

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,5 @@
 const { assoc, curryN, flip, is, when } = require('ramda')
+const CorsError = require('./cors-error')
 
 exports.assign = (key, obj) =>
   flip(assoc(key))(obj)
@@ -11,6 +12,6 @@ exports.log = (logger, output) => () =>
 
 exports.rethrow = logger =>
   when(is(Error), err => {
-    typeof logger === 'function' && logger(err)
+    typeof logger === 'function' && logger(CorsError.unwrap(err))
     throw err
   })

--- a/test/cors-error.js
+++ b/test/cors-error.js
@@ -1,0 +1,30 @@
+const { expect } = require('chai')
+const CorsError = require('../lib/cors-error')
+
+describe('cors error object', () => {
+
+  it('is an `Error`', () => {
+    expect(CorsError.prototype).to.be.instanceOf(Error)
+  })
+
+  it('constructs', () => {
+    const err = new Error('foobar')
+    const headers = { mock: 'headers' }
+    const result = new CorsError(err, headers)
+    expect(result.err).to.equal(err)
+    expect(result.headers).to.equal(headers)
+  })
+
+  it('unwraps `CorsError`', () => {
+    const err = new Error('foobar')
+    const headers = { mock: 'headers' }
+    const result = new CorsError(err, headers)
+    expect(CorsError.unwrap(result)).to.equal(err)
+  })
+
+  it('passes through other errors', () => {
+    const err = new Error('foobar')
+    expect(CorsError.unwrap(err)).to.equal(err)
+  })
+
+})


### PR DESCRIPTION
Paperplane currently does not add CORS headers if a handler throws. I have hacked together a solution by wrapping any errors in a `CorsError` object with headers, & unwrapping it in `errors.js`.