### PR TITLE
Always Add CORS headers to Response

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,4 +1,4 @@
-const { compose, defaultTo, lensProp, merge, over } = require('ramda')
+const { lensProp, merge, over } = require('ramda')
 
 const defs = {
   credentials: 'true',

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,4 +1,4 @@
-const { evolve, merge } = require('ramda')
+const { compose, defaultTo, lensProp, merge, over } = require('ramda')
 
 const defs = {
   credentials: 'true',
@@ -27,5 +27,5 @@ const options = opts => ({ headers }) => ({
 module.exports = (app, opts={}) => req =>
   Promise.resolve(req)
     .then(req.method === 'OPTIONS' && options(opts) || app)
-    .then(evolve({ headers: merge(basics(opts)) }))
+    .then(over(lensProp('headers'), merge(basics(opts))))
     .catch(corsifyError(opts))

--- a/test/cors.js
+++ b/test/cors.js
@@ -64,6 +64,20 @@ describe('cors', () => {
         )
       })
 
+      describe('when the request succeeds, no content', () => {
+        const app    = cors(K({ statusCode: 204 })),
+              server = http.createServer(mount(app)),
+              agent  = request.agent(server)
+
+        it('defaults the credentials to true', () =>
+          agent.get('/').expect('access-control-allow-credentials', 'true')
+        )
+
+        it('defaults the origin to "*"', () =>
+          agent.get('/').expect('access-control-allow-origin', '*')
+        )
+      })
+
       describe('when the request fails with boom', () => {
         const app    = cors(boomError),
               server = http.createServer(mount(app)),


### PR DESCRIPTION
[`R.evolve`](http://ramdajs.com/docs/#evolve) will not perform any transformations if a corresponding key is not in the given object. Thus if a handler does not have a `headers` key, the CORS headers will not be added to the response.

This uses `R.over` instead to always add CORS headers.