### PR TITLE
Allow serving of sub-paths.

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -4,7 +4,7 @@ const methods = require('./methods')
 const send    = require('./send')
 
 const serve = opts => methods({
-  GET: req => send(sendStream(req, req.params.path.join("/"), opts))
+  GET: req => send(sendStream(req, req.params.path.join('/'), opts))
 })
 
 module.exports = serve

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -4,7 +4,7 @@ const methods = require('./methods')
 const send    = require('./send')
 
 const serve = opts => methods({
-  GET: req => send(sendStream(req, req.params.path, opts))
+  GET: req => send(sendStream(req, req.params.path.join("/"), opts))
 })
 
 module.exports = serve

--- a/test/fixtures/sub/static-file.txt
+++ b/test/fixtures/sub/static-file.txt
@@ -1,0 +1,1 @@
+testing testing sub

--- a/test/serve.js
+++ b/test/serve.js
@@ -18,6 +18,10 @@ describe('serve', () => {
     agent.get('/pub/static-file.txt').expect(200, 'testing testing' + EOL)
   )
 
+  it('responds with found for sub paths', () =>
+    agent.get('/pub/sub/static-file.txt').expect(200, 'testing testing sub' + EOL)
+  )
+
   it('404 Not Founds for missing static files', () =>
     agent.get('/pub/not-a-file.png').expect(404)
   )


### PR DESCRIPTION
This fixes `serve` so the following works:

```
'/static/:path+': serve({
  root: "static"
}),
```

Now when you make a request to `/static/js/file.js` it properly serves `js/file.js` from the path `static`.

![](https://media1.tenor.com/images/8b517eec430d9e1f1c64f93b90de3f44/tenor.gif?itemid=4627161)