### PR TITLE
Don't explode when content-type missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '7'
   - '6'
 before_install:
-  - npm install -g yarn@1.3.2
+  - npm install -g yarn@1.7.0
 install:
   - yarn install --pure-lockfile
 script:

--- a/lib/get-body.js
+++ b/lib/get-body.js
@@ -1,15 +1,19 @@
-const { compose, path, when } = require('ramda')
-const rawBody = require('raw-body')
+const { always, assoc, compose, curryN, objOf, path, when } = require('ramda')
+const rawBody = curryN(2, require('raw-body'))
 const typer   = require('media-typer')
 
 const { assign } = require('./util')
 
-const contentLength = compose(parseInt, path(['headers', 'content-length']))
+const contentLength = compose(Number, path(['headers', 'content-length']))
 
-const getBody = req => {
-  const encoding = typer.parse(req).parameters.charset || 'utf8'
-  return rawBody(req, { encoding, length: contentLength(req) })
+const getBody = req =>
+  Promise.resolve(req)
+    .then(typer.parse)
+    .then(path(['parameters', 'charset']))
+    .catch(always('utf8'))
+    .then(objOf('encoding'))
+    .then(assoc('length', contentLength(req)))
+    .then(rawBody(req))
     .then(assign('body', req))
-}
 
 module.exports = when(contentLength, getBody)

--- a/test/mount.js
+++ b/test/mount.js
@@ -92,6 +92,15 @@ describe('mount', () => {
           .expect(200)
       )
     })
+
+    describe('when content-type is missing', () => {
+      it('does not explode', () =>
+        agent.post('/body')
+          .send('body')
+          .set('content-type', '')
+          .expect(200)
+      )
+    })
   })
 
   describe('response body', () => {


### PR DESCRIPTION
![dilbert explode](https://i.pinimg.com/originals/30/32/43/303243e5adaf3119e6d418f98cdc328b.gif)

Discovered recently that a _certain CLI tool_ doesn't send `content-type` headers.  Perhaps if all requests are always JSON, then you can save some bits by not specifying `content-type: application/json` every time.  Whatevs.  That's silly.

Regardless, `paperplane` shouldn't care if you're a negligent engineer.  This PR catches those nasty errors and assumes your body encoding is `utf8`, which was our default before anyways.