### PR TITLE
Default charset to utf8 better

### DIFF
--- a/lib/getBody.js
+++ b/lib/getBody.js
@@ -1,4 +1,7 @@
-const { always, assoc, compose, curryN, objOf, path, when } = require('ramda')
+const {
+  always, assoc, compose, curryN, objOf, path, pathOr, when
+} = require('ramda')
+
 const { assocWithP } = require('@articulate/funky')
 const rawBody = curryN(2, require('raw-body'))
 const typer = require('media-typer')
@@ -8,7 +11,7 @@ const contentLength = compose(Number, path(['headers', 'content-length']))
 const getBody = req =>
   Promise.resolve(req)
     .then(typer.parse)
-    .then(path(['parameters', 'charset']))
+    .then(pathOr('utf8', ['parameters', 'charset']))
     .catch(always('utf8'))
     .then(objOf('encoding'))
     .then(assoc('length', contentLength(req)))


### PR DESCRIPTION
![dilbert charset](http://fontzzz.com/fonts/sect11/dilbertfont2/img/map2_DILBERTFONT2.ttf.png)

There appears to be a real Dilbert font.  I will be installing it shortly.

More on topic: I thought I was defaulting the charset to `utf8` correctly, but it appears that sometimes `media-typer` won't reject, but will instead return an `undefined` charset.  Shame on you, `media-typer`!