### PR TITLE
Add original request and matched route pattern to Request object

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,6 +118,7 @@ The `Request` object is the sole input to your handler function, and has the fol
 | `pathname` | `String` | just the path portion of the request url |
 | `protocol` | `String` | `https` if connection is encrypted, otherwise `http` |
 | `query` | `Object` | map of query string parameters |
+| `route` | `String` | matched route pattern, only present if [`routes`](https://github.com/articulate/paperplane/blob/master/docs/API.md#routes) function used |
 | `url` | `String` | the full [request url](http://devdocs.io/node/http#http_message_url) |
 
 ### `Response` object

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,10 +110,11 @@ The `Request` object is the sole input to your handler function, and has the fol
 | Property | Type | Details |
 | -------- | ---- | ------- |
 | `body` | `String` | request body, with default charset of `utf8` |
-| `context` | `Object` | [`requestContext`](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format) from a Lambda proxy event, only present if `{ lambda: true }` enabled |
+| `context` | `Object` | [`requestContext`](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format) from a Lambda proxy event, only present in [serverless mode](https://github.com/articulate/paperplane/blob/master/docs/API.md#serverless-deployment) |
 | `cookies` | `Object` | map of cookies, parsed from the `cookie` header |
 | `headers` | `Object` | map of headers, with downcased header names as keys |
 | `method` | `String` | request method, should be uppercase |
+| `original` | [`IncomingMessage`](https://devdocs.io/node/http#http_class_http_incomingmessage) | reference to the original request object, not present in [serverless mode](https://github.com/articulate/paperplane/blob/master/docs/API.md#serverless-deployment) |
 | `params` | `Object` | map of named route parameters, only present if [`routes`](https://github.com/articulate/paperplane/blob/master/docs/API.md#routes) function used |
 | `pathname` | `String` | just the path portion of the request url |
 | `protocol` | `String` | `https` if connection is encrypted, otherwise `http` |

--- a/lib/cleanRequest.js
+++ b/lib/cleanRequest.js
@@ -5,6 +5,7 @@ module.exports = pick([
   'cookies',
   'headers',
   'method',
+  'original',
   'params',
   'pathname',
   'protocol',

--- a/lib/mount.js
+++ b/lib/mount.js
@@ -1,4 +1,5 @@
 const { compose, identity, is, when, tap } = require('ramda')
+const { assocWith } = require('@articulate/funky')
 
 const bufferStreams  = require('./bufferStreams')
 const cleanRequest   = require('./cleanRequest')
@@ -26,6 +27,7 @@ const mount = (opts={}) => {
 
   const httpListener = (req, res) =>
     Promise.resolve(req)
+      .then(assocWith('original', identity))
       .then(getBody)
       .then(parseUrl)
       .then(parseCookies)

--- a/lib/mount.js
+++ b/lib/mount.js
@@ -13,6 +13,9 @@ const wrap           = require('./wrap')
 const writeHTTP      = require('./writeHTTP')
 const writeLambda    = require('./writeLambda')
 
+const keepOriginal =
+  assocWith('original', identity)
+
 const mount = (opts={}) => {
   const {
     app        = identity,
@@ -27,7 +30,7 @@ const mount = (opts={}) => {
 
   const httpListener = (req, res) =>
     Promise.resolve(req)
-      .then(assocWith('original', identity))
+      .then(keepOriginal)
       .then(getBody)
       .then(parseUrl)
       .then(parseCookies)
@@ -52,7 +55,9 @@ const mount = (opts={}) => {
   const wrapError = req =>
     when(is(Error), compose(error, tap(sob(req))))
 
-  return lambda ? compose(lambdaHandler, eventToRequest) : httpListener
+  return lambda
+    ? compose(lambdaHandler, eventToRequest)
+    : httpListener
 }
 
 module.exports = mount

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -6,7 +6,9 @@ const routes = (handlers, req) => {
   for (let route in handlers) {
     const params = pathMatch(route)(req.pathname)
     if (params) {
-      return Promise.resolve(merge(req, { params })).then(handlers[route])
+      return Promise.resolve({ params, route })
+        .then(merge(req))
+        .then(handlers[route])
     }
   }
   return Promise.reject(Boom.notFound())

--- a/test/mount.js
+++ b/test/mount.js
@@ -27,6 +27,7 @@ describe('mount', () => {
     '/http':     () => { throw new NotFound() },
     '/joi':      () => validate(Joi.string(), 123),
     '/json':     K(json({})),
+    '/original': req => json({ hasOriginal: req.original instanceof http.IncomingMessage }),
     '/protocol': compose(json, pick(['protocol'])),
     '/none':     K({ body: undefined }),
     '/stream':   () => ({ body: str('stream') }),
@@ -70,6 +71,11 @@ describe('mount', () => {
             done()
           })
       })
+
+      it('includes a reference to original request object', () =>
+        agent.get('/original')
+          .expect(200, { hasOriginal: true })
+      )
     })
 
     describe('request headers', () => {


### PR DESCRIPTION
![dilbert](https://assets.amuniversal.com/05069d609fc6012f2fe600163e41dd5b)

Does what it says on the tin.  This is to support tracing with services like `DataDog`.

## to test:
- [ ] Review the code.
- [ ] Agree or disagree on the `original` name.
- [ ] Watch the tests green up.