### PR TITLE
Also log any extra data attached to an error

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,11 +2,12 @@ const {
   converge, evolve, identity, is, merge, pick, pipe, tap, when
 } = require('ramda')
 
-const clean =
+const nonEnumerable =
   pick(['message', 'name', 'stack'])
 
+// flattens non-enumerable props into a serializable object
 const flattenProps =
-  converge(merge, [ identity, clean ])
+  converge(merge, [ identity, nonEnumerable ])
 
 const logger =
   tap(

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,9 +1,17 @@
-const { evolve, is, pick, pipe, tap, when } = require('ramda')
+const {
+  converge, evolve, identity, is, merge, pick, pipe, tap, when
+} = require('ramda')
 
-module.exports =
+const clean =
+  pick(['message', 'name', 'stack'])
+
+const flattenProps =
+  converge(merge, [ identity, clean ])
+
+const logger =
   tap(
     pipe(
-      when(is(Error), pick(['message', 'name', 'stack'])),
+      when(is(Error), flattenProps),
       evolve({
         req: pick(['headers', 'method', 'url']),
         res: pick(['statusCode'])
@@ -12,3 +20,5 @@ module.exports =
       console.info
     )
   )
+
+module.exports = logger

--- a/test/logger.js
+++ b/test/logger.js
@@ -61,9 +61,11 @@ describe('logger', () => {
     )
   })
 
-  describe('when used as the errLogger', () => {
+  describe('when used as the cry', () => {
     beforeEach(() => {
-      logger(new Error('message'))
+      const err = new Error('message')
+      err.extraData = { foo: 'bar' }
+      logger(err)
       output = JSON.parse(console.info.calls[0][0])
     })
 
@@ -77,6 +79,10 @@ describe('logger', () => {
 
     it('includes the error stack', () =>
       expect(output.stack).to.exist
+    )
+
+    it('includes any extra data attached to the error', () =>
+      expect(output.extraData).to.eql({ foo: 'bar' })
     )
   })
 })


### PR DESCRIPTION
![Screen Shot 2019-07-18 at 5 06 24 PM](https://user-images.githubusercontent.com/888052/61491986-6c551700-a97e-11e9-95d3-7b2b3877b36a.png)

I want to fix this problem in Datadog.  But currently we clean errors before logging them, and just log the `{ message, name, stack }`.  Any injected trace ids would be scrubbed, and errors would not be attached to the corresponding traces.

This PR fixes that, by continuing to log at least the `{ message, name, stack }` for errors, but also any other data that is attached to the error.